### PR TITLE
Fix Issues

### DIFF
--- a/SDDB/DatabaseDiscord.py
+++ b/SDDB/DatabaseDiscord.py
@@ -938,7 +938,7 @@ class TableRow:
 			raise TypeError("index must be an int")
 		if index > len(self.headers) or index < 0:
 			raise IndexError("index out of bounds")
-		self.records[index] = TableRecord(self.headers[index], data.strip())
+		self.records[index] = TableRecord(self.headers[index], data.strip() if type(data) == str else data)
 
 	def writable(self):
 		"""String of TableRow excluding id for writing to the database"""


### PR DESCRIPTION
# Fixes for newer versions

- **Fix Flatten issues:** An AttributeError was raised when calling the flatten() method on an async_generator object. The ```flatten()``` method cannot be used because ```t.history(limit=1024```) returns an async_generator object, and ```flatten()``` is not a valid method for async_generator objects

- **Fix Integer Parsing Issue:** An error occurred when trying to parse an integer into the strip function. This occurred when trying to add new items into the database.
